### PR TITLE
dfs_over with polymorphic element types

### DIFF
--- a/src/iter/dfs.rs
+++ b/src/iter/dfs.rs
@@ -1,4 +1,4 @@
-use super::kind::{IterKind, StackElement};
+use super::kind_core::{IterKindCore, StackElement};
 use crate::{
     helpers::N,
     tree::{DefaultMemory, DefaultPinVec},
@@ -11,9 +11,15 @@ use orx_self_or::SoM;
 use orx_selfref_col::{MemoryPolicy, NodePtr, SelfRefCol};
 
 /// A depth first search iterator; also known as "pre-order traversal" ([wiki](https://en.wikipedia.org/wiki/Tree_traversal#Pre-order_implementation)).
-pub struct Dfs<'a, K, V, M = DefaultMemory<V>, P = DefaultPinVec<V>, S = Vec<NodePtr<V>>>
-where
-    K: IterKind<'a, V, M, P>,
+pub struct Dfs<
+    'a,
+    K,
+    V,
+    M = DefaultMemory<V>,
+    P = DefaultPinVec<V>,
+    S = Vec<<K as IterKindCore<'a, V, M, P>>::StackElement>,
+> where
+    K: IterKindCore<'a, V, M, P>,
     V: TreeVariant,
     M: MemoryPolicy<V>,
     P: PinnedVec<N<V>>,
@@ -24,9 +30,22 @@ where
     phantom: PhantomData<K>,
 }
 
+impl<'a, K, V, M, P, S> From<Dfs<'a, K, V, M, P, S>> for (&'a SelfRefCol<V, M, P>, S)
+where
+    K: IterKindCore<'a, V, M, P>,
+    V: TreeVariant,
+    M: MemoryPolicy<V>,
+    P: PinnedVec<N<V>>,
+    S: SoM<Vec<K::StackElement>>,
+{
+    fn from(value: Dfs<'a, K, V, M, P, S>) -> Self {
+        (value.col, value.stack)
+    }
+}
+
 impl<'a, K, V, M, P> Dfs<'a, K, V, M, P, Vec<K::StackElement>>
 where
-    K: IterKind<'a, V, M, P>,
+    K: IterKindCore<'a, V, M, P>,
     V: TreeVariant,
     M: MemoryPolicy<V>,
     P: PinnedVec<N<V>>,
@@ -46,7 +65,7 @@ where
 
 impl<'a, K, V, M, P> Dfs<'a, K, V, M, P, &'a mut Vec<K::StackElement>>
 where
-    K: IterKind<'a, V, M, P>,
+    K: IterKindCore<'a, V, M, P>,
     V: TreeVariant,
     M: MemoryPolicy<V>,
     P: PinnedVec<N<V>>,
@@ -70,7 +89,7 @@ where
 
 impl<'a, K, V, M, P, S> Iterator for Dfs<'a, K, V, M, P, S>
 where
-    K: IterKind<'a, V, M, P>,
+    K: IterKindCore<'a, V, M, P>,
     V: TreeVariant + 'a,
     M: MemoryPolicy<V> + 'a,
     P: PinnedVec<N<V>> + 'a,

--- a/src/iter/kind_core.rs
+++ b/src/iter/kind_core.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use orx_pinned_vec::PinnedVec;
 use orx_selfref_col::{MemoryPolicy, NodePtr, SelfRefCol};
 
-pub trait IterKind<'a, V, M, P>
+pub trait IterKindCore<'a, V, M, P>
 where
     V: TreeVariant + 'a,
     M: MemoryPolicy<V> + 'a,
@@ -13,7 +13,7 @@ where
 
     type ValueFromNode: ValueFromNode<'a, V, M, P>;
 
-    type YieldElement;
+    type YieldElement: Clone;
 
     fn children(parent: &Self::StackElement) -> impl Iterator<Item = Self::StackElement> + 'a;
 
@@ -27,7 +27,7 @@ where
 
 pub struct NodeVal<D>(PhantomData<D>);
 
-impl<'a, V, M, P, D> IterKind<'a, V, M, P> for NodeVal<D>
+impl<'a, V, M, P, D> IterKindCore<'a, V, M, P> for NodeVal<D>
 where
     V: TreeVariant + 'a,
     M: MemoryPolicy<V> + 'a,
@@ -58,7 +58,7 @@ where
 
 pub struct NodeDepthVal<D>(PhantomData<D>);
 
-impl<'a, V, M, P, D> IterKind<'a, V, M, P> for NodeDepthVal<D>
+impl<'a, V, M, P, D> IterKindCore<'a, V, M, P> for NodeDepthVal<D>
 where
     V: TreeVariant + 'a,
     M: MemoryPolicy<V> + 'a,
@@ -97,7 +97,7 @@ where
 
 pub struct NodeDepthSiblingVal<D>(PhantomData<D>);
 
-impl<'a, V, M, P, D> IterKind<'a, V, M, P> for NodeDepthSiblingVal<D>
+impl<'a, V, M, P, D> IterKindCore<'a, V, M, P> for NodeDepthSiblingVal<D>
 where
     V: TreeVariant + 'a,
     M: MemoryPolicy<V> + 'a,
@@ -120,8 +120,8 @@ where
         node(parent.node_ptr())
             .next()
             .children_ptr()
-            .rev()
             .enumerate()
+            .rev()
             .map(move |(i, ptr)| (depth, i, ptr.clone()))
     }
 
@@ -202,7 +202,7 @@ where
     M: MemoryPolicy<V> + 'a,
     P: PinnedVec<N<V>> + 'a,
 {
-    type Value;
+    type Value: Clone;
 
     fn value(col: &'a SelfRefCol<V, M, P>, node: &'a N<V>) -> Self::Value;
 }

--- a/src/iter/kind_over.rs
+++ b/src/iter/kind_over.rs
@@ -1,0 +1,82 @@
+use super::{DataFromNode, IterKindCore, NodeDepthSiblingVal, NodeDepthVal, NodeFromNode, NodeVal};
+use crate::{helpers::N, TreeVariant};
+use orx_pinned_vec::PinnedVec;
+use orx_selfref_col::MemoryPolicy;
+
+pub trait IterOver {
+    type IterKind<'a, V, M, P>: IterKindCore<'a, V, M, P>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+// data
+
+pub struct OverData;
+
+impl IterOver for OverData {
+    type IterKind<'a, V, M, P>
+        = NodeVal<DataFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+pub struct OverDepthData;
+
+impl IterOver for OverDepthData {
+    type IterKind<'a, V, M, P>
+        = NodeDepthVal<DataFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+pub struct OverDepthSiblingData;
+
+impl IterOver for OverDepthSiblingData {
+    type IterKind<'a, V, M, P>
+        = NodeDepthSiblingVal<DataFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+// node
+
+pub struct OverNode;
+
+impl IterOver for OverNode {
+    type IterKind<'a, V, M, P>
+        = NodeVal<NodeFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+pub struct OverDepthNode;
+
+impl IterOver for OverDepthNode {
+    type IterKind<'a, V, M, P>
+        = NodeDepthVal<NodeFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}
+
+pub struct OverDepthSiblingNode;
+
+impl IterOver for OverDepthSiblingNode {
+    type IterKind<'a, V, M, P>
+        = NodeDepthSiblingVal<NodeFromNode>
+    where
+        V: TreeVariant + 'a,
+        M: MemoryPolicy<V> + 'a,
+        P: PinnedVec<N<V>> + 'a;
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,5 +1,12 @@
 mod dfs;
-mod kind;
+mod kind_core;
+mod kind_over;
 
 pub use dfs::Dfs;
-pub use kind::{DataFromNode, IterKind, NodeDepthSiblingVal, NodeDepthVal, NodeFromNode, NodeVal};
+pub use kind_core::{
+    DataFromNode, IterKindCore, NodeDepthSiblingVal, NodeDepthVal, NodeFromNode, NodeVal,
+};
+pub use kind_over::{
+    IterOver, OverData, OverDepthData, OverDepthNode, OverDepthSiblingData, OverDepthSiblingNode,
+    OverNode,
+};

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,6 +18,20 @@ where
     node_ptr: NodePtr<V>,
 }
 
+impl<'a, V, M, P> Clone for Node<'a, V, M, P>
+where
+    V: TreeVariant,
+    M: MemoryPolicy<V>,
+    P: PinnedVec<N<V>>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            col: self.col,
+            node_ptr: self.node_ptr.clone(),
+        }
+    }
+}
+
 impl<'a, V, M, P> Node<'a, V, M, P>
 where
     V: TreeVariant,


### PR DESCRIPTION
One method to rule them all => `dfs_over` method creates depth-first iterator yielding different useful element types depending on its generic parameter with expressive names, such as: `OverData` or `OverDepthNode`, etc.