### PR TITLE
push does not return index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,5 @@ orx-selfref-col = { path = "../orx-selfref-col" }
 orx-self-or = "1.0"
 
 [features]
-default = ["std"]
+default = []
 std = []
-
-[lib]
-doctest = true

--- a/src/node_ref.rs
+++ b/src/node_ref.rs
@@ -74,9 +74,9 @@ where
     /// let mut root = tree.root_mut().unwrap();
     /// assert_eq!(root.data(), &0);
     ///
-    /// let a = root.push(1);
-    /// let node = tree.node(&a).unwrap();
-    /// assert_eq!(node.data(), &1);
+    /// let [id_a] = root.grow([1]);
+    /// let a = id_a.node(&tree);
+    /// assert_eq!(a.data(), &1);
     /// ```
     #[inline(always)]
     #[allow(clippy::missing_panics_doc)]
@@ -101,15 +101,15 @@ where
     /// let mut root = tree.root_mut().unwrap();
     /// assert_eq!(root.num_children(), 0);
     ///
-    /// let a = root.push(1);
-    /// let b = root.push(2);
+    /// let [id_a, id_b] = root.grow([1, 2]);
     /// assert_eq!(root.num_children(), 2);
     ///
-    /// let mut node = tree.node_mut(&a).unwrap();
-    /// node.extend([3, 4, 5, 6]);
+    /// let mut node = id_a.node_mut(&mut tree);
+    /// node.push(3);
+    /// node.extend([4, 5, 6]);
     /// assert_eq!(node.num_children(), 4);
     ///
-    /// assert_eq!(tree.node(&b).unwrap().num_children(), 0);
+    /// assert_eq!(id_b.node(&tree).num_children(), 0);
     /// ```
     fn num_children(&self) -> usize {
         self.node().next().num_children()
@@ -130,11 +130,11 @@ where
     /// let mut tree = DynTree::<char>::new('r');
     ///
     /// let mut root = tree.root_mut().unwrap();
-    /// let a = root.push('a');
+    /// let [id_a] = root.grow(['a']);
     /// root.push('b');
     ///
-    /// let mut node_a = tree.node_mut(&a).unwrap();
-    /// node_a.extend(['c', 'd', 'e']);
+    /// let mut a = id_a.node_mut(&mut tree);
+    /// a.extend(['c', 'd', 'e']);
     ///
     /// // iterate over children of nodes
     ///
@@ -180,11 +180,11 @@ where
     /// let mut tree = DynTree::<char>::new('r');
     ///
     /// let mut root = tree.root_mut().unwrap();
-    /// let a = root.push('a');
+    /// let [id_a] = root.grow(['a']);
     /// root.push('b');
     ///
-    /// let mut node_a = tree.node_mut(&a).unwrap();
-    /// node_a.extend(['c', 'd', 'e']);
+    /// let mut a = id_a.node_mut(&mut tree);
+    /// a.extend(['c', 'd', 'e']);
     ///
     /// // use child to access lower level nodes
     ///
@@ -353,7 +353,7 @@ where
     /// assert_eq!(values, [3, 6, 9, 7, 10, 11]);
     ///
     /// let idx6 = &n3_children_idx[0];
-    /// let n6 = tree.node(idx6).unwrap();
+    /// let n6 = idx6.node(&tree);
     /// let values: Vec<_> = n6.dfs().copied().collect();
     /// assert_eq!(values, [6, 9]);
     /// ```
@@ -577,7 +577,7 @@ where
     /// assert_eq!(values, [3, 6, 7, 9, 10, 11]);
     ///
     /// let idx6 = &n3_children_idx[0];
-    /// let n6 = tree.node(idx6).unwrap();
+    /// let n6 = idx6.node(&tree);
     /// let values: Vec<_> = n6.bfs().copied().collect();
     /// assert_eq!(values, [6, 9]);
     /// ```

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -81,12 +81,13 @@ where
     /// assert_eq!(tree.len(), 1);
     ///
     /// let mut root = tree.root_mut().unwrap();
-    /// let _ = root.push(4);
-    /// let idx = root.push(2);
+    /// let [_, idx] = root.grow([4, 2]);
+    ///
     /// assert_eq!(tree.len(), 3);
     ///
-    /// let mut node = tree.node_mut(&idx).unwrap();
+    /// let mut node = idx.node_mut(&mut tree);
     /// node.push(7);
+    ///
     /// assert_eq!(tree.len(), 4);
     /// ```
     #[inline(always)]
@@ -145,9 +146,9 @@ where
     ///
     /// let mut root = tree.root_mut().unwrap();
     /// root.push(4);
-    /// let idx = root.push(2);
+    /// let [idx] = root.grow([2]);
     ///
-    /// let mut node = tree.node_mut(&idx).unwrap();
+    /// let mut node = idx.node_mut(&mut tree);
     /// node.push(7);
     ///
     /// assert_eq!(tree.len(), 4);
@@ -218,54 +219,31 @@ where
 
     /// Returns the node with the given `node_idx`; returns None if the index is invalid.
     ///
+    /// A node index is valid iff it satisfies the following three conditions:
+    ///
+    /// * It is created from a node of this tree.
+    /// * The node is not removed from the tree.
+    /// * Tree memory state has not changed since the index is created.
+    ///
     /// # Examples
     ///
-    /// ```
-    /// use orx_tree::*;
-    ///
-    /// let mut tree = BinaryTree::<_>::new('a');
-    ///
-    /// let mut root = tree.root_mut().unwrap();
-    /// let b = root.push('b');
-    /// let c = root.push('c');
-    ///
-    /// assert_eq!(tree.node(&b).map(|x| *x.data()), Some('b'));
-    ///
-    /// let node = tree.node(&c).unwrap();
-    /// assert_eq!(node.data(), &'c');
-    ///
-    /// tree.clear();
-    /// assert!(tree.is_empty());
-    /// assert_eq!(tree.node(&b), None);
-    /// assert_eq!(tree.node(&c), None);
-    /// ```
-    pub fn node(&self, node_idx: &NodeIdx<V>) -> Option<Node<V, M, P>> {
+    /// TODO: examples mentioning the memory state
+    pub fn get_node(&self, node_idx: &NodeIdx<V>) -> Option<Node<V, M, P>> {
         self.0.get_ptr(node_idx).map(|p| Node::new(&self.0, p))
     }
 
     /// Returns the mutable node with the given `node_idx`; returns None if the index is invalid.
     ///
+    /// A node index is valid iff it satisfies the following three conditions:
+    ///
+    /// * It is created from a node of this tree.
+    /// * The node is not removed from the tree.
+    /// * Tree memory state has not changed since the index is created.
+    ///
     /// # Examples
     ///
-    /// ```
-    /// use orx_tree::*;
-    ///
-    /// let mut tree = DynTree::<_>::new('a');
-    ///
-    /// let mut root = tree.root_mut().unwrap();
-    /// let b = root.push('b');
-    /// let c = root.push('c');
-    ///
-    /// let mut node = tree.node_mut(&b).unwrap();
-    /// node.extend(['d', 'e', 'f']);
-    ///
-    /// assert_eq!(node.num_children(), 3);
-    ///
-    /// tree.clear();
-    /// assert!(tree.is_empty());
-    /// assert_eq!(tree.node_mut(&b), None);
-    /// ```
-    pub fn node_mut(&mut self, node_idx: &NodeIdx<V>) -> Option<NodeMut<V, M, P>> {
+    /// TODO: examples mentioning the memory state
+    pub fn get_node_mut(&mut self, node_idx: &NodeIdx<V>) -> Option<NodeMut<V, M, P>> {
         self.0
             .get_ptr(node_idx)
             .map(|p| NodeMut::new(&mut self.0, p))


### PR DESCRIPTION
In order to avoid unnecessary returns when not required push & extend methods are separated from the grow method. Only grow and grow_iter methods return the indices of the pushed children.