### PR TITLE
fix/reorganize-nodes-after-walk-into

### DIFF
--- a/src/node_mut.rs
+++ b/src/node_mut.rs
@@ -459,11 +459,13 @@ where
     /// //  ╱ ╲         |  ╱ ╲
     /// // 3   4        8 9   10
     ///
-    /// let mut a = DynTree::<_>::new(0);
+    /// // into_lazy_reclaim: to keep the indices valid
+    /// let mut a = DynTree::<_>::new(0).into_lazy_reclaim();
     /// let [id1, id2] = a.root_mut().push_children([1, 2]);
     /// a.node_mut(&id1).push_children([3, 4]);
     ///
-    /// let mut b = DaryTree::<4, _>::new(5);
+    /// // into_lazy_reclaim: to keep the indices valid
+    /// let mut b = DaryTree::<4, _>::new(5).into_lazy_reclaim();
     /// let id5 = b.root().idx();
     /// let [id6, id7] = b.root_mut().push_children([6, 7]);
     /// b.node_mut(&id6).push_child(8);
@@ -1040,11 +1042,13 @@ where
     /// //  ╱ ╲         |  ╱ ╲
     /// // 3   4        8 9   10
     ///
-    /// let mut a = DynTree::<_>::new(0);
+    /// // into_lazy_reclaim -> to keep indices valid
+    /// let mut a = DynTree::<_>::new(0).into_lazy_reclaim();
     /// let [id1, id2] = a.root_mut().push_children([1, 2]);
     /// a.node_mut(&id1).push_children([3, 4]);
     ///
-    /// let mut b = DaryTree::<4, _>::new(5);
+    /// // into_lazy_reclaim -> to keep indices valid
+    /// let mut b = DaryTree::<4, _>::new(5).into_lazy_reclaim();
     /// let [id6, id7] = b.root_mut().push_children([6, 7]);
     /// b.node_mut(&id6).push_child(8);
     /// b.node_mut(&id7).push_children([9, 10]);
@@ -2074,7 +2078,6 @@ where
     ///
     /// ```
     /// use orx_tree::*;
-    /// use orx_tree::traversal::*;
     ///
     /// //      1
     /// //     ╱ ╲

--- a/src/traversal/depth_first/into_iter.rs
+++ b/src/traversal/depth_first/into_iter.rs
@@ -18,6 +18,7 @@ where
     S: SoM<Vec<Item<V, E>>>,
 {
     col: &'a mut Col<V, M, P>,
+    root_ptr: NodePtr<V>,
     iter: DfsIterPtr<V, E, S>,
 }
 
@@ -42,14 +43,14 @@ where
     /// * Finally, this iterator's lifetime is equal to the borrow duration of the mutable node.
     #[allow(clippy::type_complexity)]
     pub(crate) unsafe fn from(
-        (col, iter, node_ptr): (&'a mut Col<V, M, P>, DfsIterPtr<V, E, S>, NodePtr<V>),
+        (col, iter, root_ptr): (&'a mut Col<V, M, P>, DfsIterPtr<V, E, S>, NodePtr<V>),
     ) -> Self {
-        let node = unsafe { &mut *node_ptr.ptr_mut() };
+        let node = unsafe { &mut *root_ptr.ptr_mut() };
 
         match node.prev().get() {
             Some(parent) => {
                 let parent = unsafe { &mut *parent.ptr_mut() };
-                let sibling_idx = parent.next_mut().remove(node_ptr.ptr() as usize);
+                let sibling_idx = parent.next_mut().remove(root_ptr.ptr() as usize);
                 debug_assert!(sibling_idx.is_some());
 
                 node.prev_mut().clear();
@@ -60,7 +61,11 @@ where
             }
         }
 
-        Self { col, iter }
+        Self {
+            col,
+            root_ptr,
+            iter,
+        }
     }
 
     fn take_element(&mut self, element: E::Item<NodePtr<V>>) -> E::Item<V::Item> {
@@ -98,5 +103,6 @@ where
         while let Some(element) = self.iter.next() {
             self.take_element(element);
         }
+        self.col.reclaim_from_closed_node(&self.root_ptr);
     }
 }

--- a/src/traversal/post_order/into_iter.rs
+++ b/src/traversal/post_order/into_iter.rs
@@ -18,6 +18,7 @@ where
     S: SoM<Vec<State<V>>>,
 {
     col: &'a mut Col<V, M, P>,
+    root_ptr: NodePtr<V>,
     iter: PostOrderIterPtr<V, E, S>,
 }
 
@@ -42,14 +43,14 @@ where
     /// * Finally, this iterator's lifetime is equal to the borrow duration of the mutable node.
     #[allow(clippy::type_complexity)]
     pub(crate) unsafe fn from(
-        (col, iter, node_ptr): (&'a mut Col<V, M, P>, PostOrderIterPtr<V, E, S>, NodePtr<V>),
+        (col, iter, root_ptr): (&'a mut Col<V, M, P>, PostOrderIterPtr<V, E, S>, NodePtr<V>),
     ) -> Self {
-        let node = unsafe { &mut *node_ptr.ptr_mut() };
+        let node = unsafe { &mut *root_ptr.ptr_mut() };
 
         match node.prev().get() {
             Some(parent) => {
                 let parent = unsafe { &mut *parent.ptr_mut() };
-                let sibling_idx = parent.next_mut().remove(node_ptr.ptr() as usize);
+                let sibling_idx = parent.next_mut().remove(root_ptr.ptr() as usize);
                 debug_assert!(sibling_idx.is_some());
 
                 node.prev_mut().clear();
@@ -60,7 +61,11 @@ where
             }
         }
 
-        Self { col, iter }
+        Self {
+            col,
+            root_ptr,
+            iter,
+        }
     }
 
     fn take_element(&mut self, element: E::Item<NodePtr<V>>) -> E::Item<V::Item> {
@@ -98,5 +103,6 @@ where
         while let Some(element) = self.iter.next() {
             self.take_element(element);
         }
+        self.col.reclaim_from_closed_node(&self.root_ptr);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -310,9 +310,34 @@ where
     ///   => [`NodeIdxError::ReorganizedCollection`]
     ///
     /// Please see [`NodeIdx`] documentation for details on the validity of node indices.
+    ///
+    /// * If [`is_node_idx_valid`] is true, then [`node_idx_error`] is None;
+    /// * If [`is_node_idx_valid`] is false, then [`node_idx_error`] is Some.
+    ///
+    /// [`is_node_idx_valid`]: crate::Tree::is_node_idx_valid
+    /// [`node_idx_error`]: crate::Tree::node_idx_error
     #[inline(always)]
     pub fn is_node_idx_valid(&self, node_idx: &NodeIdx<V>) -> bool {
         node_idx.0.is_valid_for(&self.0)
+    }
+
+    /// Returns the node index error if the `node_idx` is invalid.
+    /// Returns None if the index is valid for this tree.
+    ///
+    /// Returns Some if any of the following holds:
+    ///
+    /// * the node index is created from a different tree => [`NodeIdxError::OutOfBounds`]
+    /// * the node that this index is created for is removed from the tree => [`NodeIdxError::RemovedNode`]
+    /// * the tree is using `Auto` memory reclaim policy and nodes are reorganized due to node removals
+    ///   => [`NodeIdxError::ReorganizedCollection`]
+    ///
+    /// * If [`is_node_idx_valid`] is true, then [`node_idx_error`] is None;
+    /// * If [`is_node_idx_valid`] is false, then [`node_idx_error`] is Some.
+    ///
+    /// [`is_node_idx_valid`]: crate::Tree::is_node_idx_valid
+    /// [`node_idx_error`]: crate::Tree::node_idx_error
+    pub fn node_idx_error(&self, node_idx: &NodeIdx<V>) -> Option<NodeIdxError> {
+        self.0.node_idx_error(&node_idx.0)
     }
 
     /// Returns the node with the given `node_idx`.

--- a/src/tree_node_idx.rs
+++ b/src/tree_node_idx.rs
@@ -164,7 +164,6 @@ Please see the notes and examples of NodeIdx and MemoryPolicy:
 ///
 /// ```
 /// use orx_tree::*;
-/// use orx_tree::traversal::*;
 ///
 /// //      1
 /// //     ╱ ╲


### PR DESCRIPTION
Call to reorganize is added to drop method of into iterators of all traversals starting from the dropped root node.

Fixes #102