### PR TITLE
new methods simplified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 orx-pinned-vec = "3.11"
 orx-split-vec = "3.11"
+# orx-selfref-col = "2.3"
 orx-selfref-col = { path = "../orx-selfref-col" }
 orx-self-or = "1.0"
 orx-iterable = "1.1.1"
@@ -13,7 +14,7 @@ serde = { version = "1.0.217", optional = true, default-features = false }
 
 [dev-dependencies]
 test-case = { version = "3.3.1", default-features = false }
-serde_json = { version = "1.0.135", default-features = false, features = [
+serde_json = { version = "1.0.137", default-features = false, features = [
     "std",
 ] }
 

--- a/src/common_traits/clone.rs
+++ b/src/common_traits/clone.rs
@@ -30,7 +30,7 @@ where
     /// // |     |  ╱ ╲
     /// // 7     8 9  10
     ///
-    /// let mut tree = DynTree::<i32>::new(0);
+    /// let mut tree = DynTree::new(0);
     ///
     /// let mut root = tree.root_mut();
     /// let [id1, id2] = root.push_children([1, 2]);
@@ -69,9 +69,9 @@ where
     /// ```
     fn clone(&self) -> Self {
         match self.get_root() {
-            None => Self::empty(),
+            None => Self::default(),
             Some(root) => {
-                let mut tree = Self::new(root.data().clone());
+                let mut tree = Self::new_with_root(root.data().clone());
 
                 for child in root.children() {
                     tree.root_mut().push_child_tree(child.as_cloned_subtree());

--- a/src/common_traits/from_depth_first_iter.rs
+++ b/src/common_traits/from_depth_first_iter.rs
@@ -212,10 +212,10 @@ where
     fn try_from(value: DepthFirstSequence<V::Item, I>) -> Result<Self, Self::Error> {
         let mut iter = value.0.into_iter();
         match iter.next() {
-            None => Ok(Tree::empty()),
+            None => Ok(Tree::default()),
             Some((d, root)) => match d {
                 0 => {
-                    let mut tree = Tree::new(root);
+                    let mut tree = Tree::new_with_root(root);
                     match tree.root_mut().try_append_subtree_as_child(iter, 0) {
                         Ok(_) => Ok(tree),
                         Err((depth, succeeding_depth)) => {

--- a/src/common_traits/serde.rs
+++ b/src/common_traits/serde.rs
@@ -23,11 +23,11 @@ where
     /// ```
     /// use orx_tree::*;
     ///
-    /// let tree = BinaryTree::<i32>::empty();
+    /// let tree = BinaryTree::empty();
     /// let json = serde_json::to_string(&tree).unwrap();
     /// assert_eq!(json, "[]");
     ///
-    /// let tree = DynTree::<i32>::new(10);
+    /// let tree = DynTree::new(10);
     /// let json = serde_json::to_string(&tree).unwrap();
     /// assert_eq!(json, "[[0,10]]");
     ///
@@ -87,9 +87,7 @@ where
 {
     type Value = Tree<V, M, P>;
 
-    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-        formatter.write_str("DepthFirstSequence which is a sequence of (depth, value) pairs in depth-first traversal order.")
-    }
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {}
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
@@ -111,9 +109,7 @@ where
 
             let mut dst = tree.root_mut();
 
-            while let Some(x) = seq.next_element()? {
-                let (depth, value): (usize, V::Item) = x;
-
+            while let Some((depth, value)) = seq.next_element::<(usize, V::Item)>()? {
                 match depth > current_depth {
                     true => {
                         if depth > current_depth + 1 {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -70,7 +70,7 @@ use orx_selfref_col::{MemoryReclaimNever, MemoryReclaimOnThreshold, MemoryReclai
 /// // # 1. GROW
 ///
 /// // equivalently => DynTree::<i32, Auto>::new(1)
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let [id2, id3] = tree.root_mut().push_children([2, 3]);
 /// let [id4, _] = tree.node_mut(&id2).push_children([4, 5]);
@@ -157,7 +157,7 @@ use orx_selfref_col::{MemoryReclaimNever, MemoryReclaimOnThreshold, MemoryReclai
 /// // # 1. GROW
 ///
 /// // or just => DynTree::<i32, Lazy>::new(1);
-/// let mut tree = DynTree::<i32>::new(1).into_lazy_reclaim();
+/// let mut tree = DynTree::new(1).into_lazy_reclaim();
 ///
 /// let [id2, id3] = tree.root_mut().push_children([2, 3]);
 /// let [id4, _] = tree.node_mut(&id2).push_children([4, 5]);

--- a/src/node_mut.rs
+++ b/src/node_mut.rs
@@ -92,7 +92,7 @@ where
     /// ```
     /// use orx_tree::*;
     ///
-    /// let mut tree = DynTree::<i32>::new(0);
+    /// let mut tree = DynTree::new(0);
     ///
     /// let mut root = tree.root_mut();
     ///
@@ -137,7 +137,7 @@ where
     /// //  ╱ ╲   ╱
     /// // 4   5 6
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let id1 = root.idx();
@@ -703,7 +703,7 @@ where
     /// //  ╱ ╲     ╲
     /// // 4   5     6
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -778,7 +778,7 @@ where
     /// //  ╱ ╲     ╲
     /// // 4   5     6
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -867,7 +867,7 @@ where
     /// //  ╱ ╲     ╲
     /// // 4   5     6
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1323,7 +1323,7 @@ where
     /// //                         ╱ ╲
     /// //                        4   5
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1392,9 +1392,9 @@ where
     /// data of this node.
     ///
     /// > **(!)** As a method that removes nodes from the tree, this method might result in invalidating indices that are
-    /// cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
-    /// for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
-    /// section presents a convenient way that allows us to make sure that the indices are valid.
+    /// > cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
+    /// > for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
+    /// > section presents a convenient way that allows us to make sure that the indices are valid.
     ///
     /// [`Auto`]: crate::Auto
     /// [`Lazy`]: crate::Lazy
@@ -1424,7 +1424,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1515,9 +1515,9 @@ where
     /// [`prune`]: crate::NodeMut::prune
     ///
     /// > **(!)** As a method that removes nodes from the tree, this method might result in invalidating indices that are
-    /// cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
-    /// for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
-    /// section presents a convenient way that allows us to make sure that the indices are valid.
+    /// > cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
+    /// > for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
+    /// > section presents a convenient way that allows us to make sure that the indices are valid.
     ///
     /// [`Auto`]: crate::Auto
     /// [`Lazy`]: crate::Lazy
@@ -1544,7 +1544,7 @@ where
     /// // |     |  ╱ ╲         |     |                  |
     /// // 8     9 10  11       8     9                  9
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1864,7 +1864,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1944,7 +1944,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1999,7 +1999,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -2083,9 +2083,9 @@ where
     /// indices in addition to node data.
     ///
     /// > **(!)** As a method that removes nodes from the tree, this method might result in invalidating indices that are
-    /// cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
-    /// for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
-    /// section presents a convenient way that allows us to make sure that the indices are valid.
+    /// > cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
+    /// > for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
+    /// > section presents a convenient way that allows us to make sure that the indices are valid.
     ///
     /// [`Auto`]: crate::Auto
     /// [`Lazy`]: crate::Lazy
@@ -2114,7 +2114,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -2184,9 +2184,9 @@ where
     /// [`PostOrder`]: crate::PostOrder
     ///
     /// > **(!)** As a method that removes nodes from the tree, this method might result in invalidating indices that are
-    /// cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
-    /// for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
-    /// section presents a convenient way that allows us to make sure that the indices are valid.
+    /// > cached earlier in the [`Auto`] mode, but not in the [`Lazy`] mode. Please see the documentation of [MemoryPolicy]
+    /// > for details of node index validity. Specifically, the examples in the "Lazy Memory Claim: Preventing Invalid Indices"
+    /// > section presents a convenient way that allows us to make sure that the indices are valid.
     ///
     /// [`Auto`]: crate::Auto
     /// [`Lazy`]: crate::Lazy
@@ -2208,7 +2208,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -2263,7 +2263,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);

--- a/src/node_ref.rs
+++ b/src/node_ref.rs
@@ -96,7 +96,7 @@ where
     /// //  ╱ ╲   ╱
     /// // 4   5 6
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     /// assert_eq!(tree.get_root().unwrap().is_leaf(), true); // both root & leaf
     ///
     /// let mut root = tree.root_mut();
@@ -131,7 +131,7 @@ where
     /// ```
     /// use orx_tree::*;
     ///
-    /// let mut tree = DynTree::<i32>::new(0);
+    /// let mut tree = DynTree::new(0);
     ///
     /// let mut root = tree.root_mut();
     /// assert_eq!(root.data(), &0);
@@ -155,7 +155,7 @@ where
     /// ```
     /// use orx_tree::*;
     ///
-    /// let mut tree = DynTree::<i32>::new(0);
+    /// let mut tree = DynTree::new(0);
     ///
     /// let mut root = tree.root_mut();
     /// assert_eq!(root.num_children(), 0);
@@ -372,7 +372,7 @@ where
     /// // |
     /// // 8
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -431,7 +431,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -488,7 +488,7 @@ where
     /// //  ╱ ╲   ╱ ╲
     /// // 4   5 6   7
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -545,7 +545,7 @@ where
     /// //       |
     /// //       8
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -613,7 +613,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -680,7 +680,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -735,7 +735,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -831,7 +831,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -922,7 +922,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1027,7 +1027,7 @@ where
     /// // |     |  ╱ ╲
     /// // 7     8 9  10
     ///
-    /// let mut tree = DynTree::<i32>::new(0);
+    /// let mut tree = DynTree::new(0);
     ///
     /// let mut root = tree.root_mut();
     /// let [id1, id2] = root.push_children([1, 2]);
@@ -1049,7 +1049,7 @@ where
     /// // clone the subtree rooted at node 2 into another tree
     /// // which might be a different tree type
     ///
-    /// let clone: BinaryTree::<i32> = tree.node(&id2).clone_as_tree();
+    /// let clone: BinaryTree<i32> = tree.node(&id2).clone_as_tree();
     ///
     /// let bfs: Vec<_> = clone.root().walk::<Bfs>().copied().collect();
     /// assert_eq!(bfs, [2, 5, 6, 8, 9, 10]);
@@ -1060,7 +1060,7 @@ where
         P::PinnedVec<V2>: Default,
         V::Item: Clone,
     {
-        let mut tree = Tree::new(self.data().clone());
+        let mut tree = Tree::new_with_root(self.data().clone());
 
         for child in self.children() {
             tree.root_mut().push_child_tree(child.as_cloned_subtree());
@@ -1101,7 +1101,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1188,7 +1188,7 @@ where
     /// // |     |  ╱ ╲
     /// // 8     9 10  11
     ///
-    /// let mut tree = DynTree::<i32>::new(1);
+    /// let mut tree = DynTree::new(1);
     ///
     /// let mut root = tree.root_mut();
     /// let [id2, id3] = root.push_children([2, 3]);
@@ -1286,7 +1286,7 @@ where
     /// // |     |  ╱ ╲
     /// // 7     8 9  10
     ///
-    /// let mut a = DynTree::<i32>::new(0);
+    /// let mut a = DynTree::new(0);
     /// let [a1, a2] = a.root_mut().push_children([1, 2]);
     /// let [a3, _] = a.node_mut(&a1).push_children([3, 4]);
     /// a.node_mut(&a3).push_child(7);
@@ -1348,9 +1348,9 @@ where
     /// This method additionally allow for yielding node depths and sibling indices in addition to node indices.
     ///
     /// [`indices_with`]: crate::NodeRef::indices_with
-    fn indices_with<'b, T, O>(
+    fn indices_with<T, O>(
         &self,
-        traverser: &'b mut T,
+        traverser: &mut T,
     ) -> impl Iterator<Item = <O::Enumeration as Enumeration>::Item<NodeIdx<V>>>
     where
         O: Over,

--- a/src/traversal/breadth_first/tests/bfs_iter_mut.rs
+++ b/src/traversal/breadth_first/tests/bfs_iter_mut.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -43,7 +43,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn bfs_iter_ref_empty() {
-    let tree = DynTree::<i32>::empty();
+    let tree = DynTree::empty();
     let iter = BfsIterPtr::<Dyn<i32>, Val>::default();
     let mut iter =
         unsafe { BfsIterMut::<_, Auto, SplitRecursive, Val, _, &mut i32>::from((&tree.0, iter)) };

--- a/src/traversal/breadth_first/tests/bfs_iter_ptr.rs
+++ b/src/traversal/breadth_first/tests/bfs_iter_ptr.rs
@@ -18,7 +18,7 @@ use orx_selfref_col::NodePtr;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/breadth_first/tests/bfs_iter_ref.rs
+++ b/src/traversal/breadth_first/tests/bfs_iter_ref.rs
@@ -25,7 +25,7 @@ use orx_selfref_col::{NodePtr, Variant};
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -46,7 +46,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn bfs_iter_ref_empty() {
-    let tree = DynTree::<i32>::empty();
+    let tree = DynTree::empty();
     let iter = BfsIterPtr::<Dyn<i32>, Val>::default();
     let mut iter = BfsIterRef::<_, Auto, SplitRecursive, Val, _, NodePtr<_>>::from((&tree.0, iter));
     assert_eq!(iter.next(), None);

--- a/src/traversal/breadth_first/tests/bfs_traverser.rs
+++ b/src/traversal/breadth_first/tests/bfs_traverser.rs
@@ -28,7 +28,7 @@ use orx_selfref_col::Variant;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/breadth_first/tests/bfs_traverser_mut.rs
+++ b/src/traversal/breadth_first/tests/bfs_traverser_mut.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/depth_first/tests/dfs_iter_mut.rs
+++ b/src/traversal/depth_first/tests/dfs_iter_mut.rs
@@ -21,7 +21,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -42,7 +42,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn dfs_iter_ref_empty() {
-    let tree = DynTree::<i32>::empty();
+    let tree = DynTree::empty();
     let iter = DfsIterPtr::<Dyn<i32>, Val>::default();
     let mut iter =
         unsafe { DfsIterMut::<_, Auto, SplitRecursive, Val, _, &mut i32>::from((&tree.0, iter)) };

--- a/src/traversal/depth_first/tests/dfs_iter_ptr.rs
+++ b/src/traversal/depth_first/tests/dfs_iter_ptr.rs
@@ -17,7 +17,7 @@ use orx_selfref_col::NodePtr;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/depth_first/tests/dfs_iter_ref.rs
+++ b/src/traversal/depth_first/tests/dfs_iter_ref.rs
@@ -24,7 +24,7 @@ use orx_selfref_col::{NodePtr, Variant};
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -45,7 +45,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn dfs_iter_ref_empty() {
-    let tree = DynTree::<i32>::empty();
+    let tree = DynTree::empty();
     let iter = DfsIterPtr::<Dyn<i32>, Val>::default();
     let mut iter = DfsIterRef::<_, Auto, SplitRecursive, Val, _, NodePtr<_>>::from((&tree.0, iter));
     assert_eq!(iter.next(), None);

--- a/src/traversal/depth_first/tests/dfs_traverser.rs
+++ b/src/traversal/depth_first/tests/dfs_traverser.rs
@@ -28,7 +28,7 @@ use orx_selfref_col::Variant;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/depth_first/tests/dfs_traverser_mut.rs
+++ b/src/traversal/depth_first/tests/dfs_traverser_mut.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/post_order/tests/post_order_iter_mut.rs
+++ b/src/traversal/post_order/tests/post_order_iter_mut.rs
@@ -23,7 +23,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -44,7 +44,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn post_order_iter_ref_empty() {
-    let mut tree = DynTree::<i32>::empty();
+    let mut tree = DynTree::empty();
     let iter = PostOrderIterPtr::<Dyn<i32>, Val>::default();
     let mut iter = unsafe {
         PostOrderIterMut::<_, Auto, SplitRecursive, Val, _, &mut i32>::from((&mut tree.0, iter))

--- a/src/traversal/post_order/tests/post_order_iter_ptr.rs
+++ b/src/traversal/post_order/tests/post_order_iter_ptr.rs
@@ -17,7 +17,7 @@ use orx_selfref_col::NodePtr;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/post_order/tests/post_order_iter_ref.rs
+++ b/src/traversal/post_order/tests/post_order_iter_ref.rs
@@ -24,7 +24,7 @@ use orx_selfref_col::{NodePtr, Variant};
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);
@@ -45,7 +45,7 @@ fn tree() -> DynTree<i32> {
 
 #[test]
 fn post_order_iter_ref_empty() {
-    let tree = DynTree::<i32>::empty();
+    let tree = DynTree::empty();
     let iter = PostOrderIterPtr::<Dyn<i32>, Val>::default();
     let mut iter =
         PostOrderIterRef::<_, Auto, SplitRecursive, Val, _, NodePtr<_>>::from((&tree.0, iter));

--- a/src/traversal/post_order/tests/post_order_traverser.rs
+++ b/src/traversal/post_order/tests/post_order_traverser.rs
@@ -28,7 +28,7 @@ use orx_selfref_col::Variant;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/traversal/post_order/tests/post_order_traverser_mut.rs
+++ b/src/traversal/post_order/tests/post_order_traverser_mut.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 /// 8     9 10  11
 /// ```
 fn tree() -> DynTree<i32> {
-    let mut tree = DynTree::<i32>::new(1);
+    let mut tree = DynTree::new(1);
 
     let mut root = tree.root_mut();
     let [id2, id3] = root.push_children([2, 3]);

--- a/src/tree_node_idx.rs
+++ b/src/tree_node_idx.rs
@@ -65,7 +65,7 @@ Specifically, see the example in the following chapter to prevent invalid indice
 /// //    ╱   ╲
 /// //   2     3
 ///
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let mut root = tree.root_mut();
 ///
@@ -88,7 +88,7 @@ Specifically, see the example in the following chapter to prevent invalid indice
 /// //    ╱ ╱╲  ╲
 /// //   2 3  4  5
 ///
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let mut root = tree.root_mut();
 ///
@@ -108,7 +108,7 @@ Specifically, see the example in the following chapter to prevent invalid indice
 /// //    ╱ ╱╲  ╲
 /// //   2 3  4  5
 ///
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let mut root = tree.root_mut();
 ///
@@ -140,7 +140,7 @@ Specifically, see the example in the following chapter to prevent invalid indice
 /// //  ╱ ╲
 /// // 4   5
 ///
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let mut root = tree.root_mut();
 ///
@@ -174,7 +174,7 @@ Specifically, see the example in the following chapter to prevent invalid indice
 /// //  ╱ ╲
 /// // 4   5
 ///
-/// let mut tree = DynTree::<i32>::new(1);
+/// let mut tree = DynTree::new(1);
 ///
 /// let mut root = tree.root_mut();
 ///


### PR DESCRIPTION
New methods can now be called without type annotation. It will default to `Auto` memory policy and `Recursive` pinned vector. In order to create a tree with a different pinned vector, one can use `Default` trait.