### PR TITLE
chore(workflows/ci): enable CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
And PRs to any branch.

Otherwise ci would not run (at least automatically) on feature branches, like on forks.