### PR TITLE
chore(Cargo.toml): make feature explicitly listed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         toolchain: ["stable", "1.88"]
-        features: ["--features orx-parallel", "--features serde"]
+        features: ["--features parallel", "--features serde"]
         no_std_features: ["--features serde"]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ serde_json = { version = "1.0.145", default-features = false, features = [
 test-case = { version = "3.3.1", default-features = false }
 
 [features]
-default = ["orx-parallel"]
-orx-parallel = ["dep:orx-parallel"]
+default = ["parallel"]
+parallel = ["dep:orx-parallel"]
+# old name, preserved until next major version
+orx-parallel = ["parallel"]
 serde = ["dep:serde"]
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Alternatively, we can turn a mutable node into an [`into_walk`](https://docs.rs/
 
 # Features
 
-* **orx-parallel**: Tree allows efficient parallel processing through [concurrent iterators](https://crates.io/crates/orx-concurrent-iter) and [parallel iterators](https://crates.io/crates/orx-parallel). See [parallelization section](#parallelization) for details. This feature is added as default and requires **std**. Therefore, please use `cargo add orx-tree --no-default-features` for **no-std** use cases.
+* **parallel**: Tree allows efficient parallel processing through [concurrent iterators](https://crates.io/crates/orx-concurrent-iter) and [parallel iterators](https://crates.io/crates/orx-parallel). See [parallelization section](#parallelization) for details. This feature is added as default and requires **std**. Therefore, please use `cargo add orx-tree --no-default-features` for **no-std** use cases.
 
 * **serde**: Tree implements `Serialize` and `Deserialize` traits; the "serde" feature needs to be added when required. It uses a linearized representation of the tree as a [`DepthFirstSequence`](https://docs.rs/orx-tree/latest/orx_tree/struct.DepthFirstSequence.html). You may find de-serialization examples in the corresponding [test file](https://github.com/orxfun/orx-tree/blob/main/tests/serde.rs).
 

--- a/benches/children_iterator.rs
+++ b/benches/children_iterator.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::ParIter;
 use orx_tree::*;
 
@@ -47,7 +47,7 @@ fn children(tree: &DynTree<String>) -> u64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn children_par(tree: &DynTree<String>) -> u64 {
     tree.root()
         .children_par()
@@ -55,7 +55,7 @@ fn children_par(tree: &DynTree<String>) -> u64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn children_par_2threads(tree: &DynTree<String>) -> u64 {
     tree.root()
         .children_par()
@@ -80,7 +80,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| children(&tree))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
             BenchmarkId::new("NNodeRef::children_par()", n),
             n,
@@ -91,7 +91,7 @@ fn bench(c: &mut Criterion) {
             },
         );
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
             BenchmarkId::new("NodeRef::children_par().num_threads(2)", n),
             n,

--- a/benches/parallelization_owned.rs
+++ b/benches/parallelization_owned.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::ParIter;
 use orx_tree::*;
 use rayon::iter::{ParallelBridge, ParallelIterator};
@@ -56,7 +56,7 @@ fn tree_into_bfs(mut tree: DynTree<String>) -> i64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn tree_into_par_x(tree: DynTree<String>) -> i64 {
     tree.into_par()
         .map(|x| x.parse::<usize>().unwrap())
@@ -108,9 +108,9 @@ fn bench(c: &mut Criterion) {
             },
         );
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
-            BenchmarkId::new("Tree::into_par_x() - orx-parallel", n),
+            BenchmarkId::new("Tree::into_par_x() - parallel", n),
             n,
             |b, _| {
                 let result = tree_into_par_x(data.clone());

--- a/benches/parallelization_ref.rs
+++ b/benches/parallelization_ref.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::ParIter;
 use orx_tree::*;
 use rayon::iter::{ParallelBridge, ParallelIterator};
@@ -56,7 +56,7 @@ fn tree_bfs(tree: &DynTree<String>) -> i64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn tree_par_x(tree: &DynTree<String>) -> i64 {
     tree.par()
         .map(|x| x.parse::<usize>().unwrap())
@@ -108,9 +108,9 @@ fn bench(c: &mut Criterion) {
             },
         );
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
-            BenchmarkId::new("Tree::par_x() - orx-parallel", n),
+            BenchmarkId::new("Tree::par_x() - parallel", n),
             n,
             |b, _| {
                 let result = tree_par_x(&data);

--- a/benches/paths_iterator.rs
+++ b/benches/paths_iterator.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use orx_iterable::{IntoCloningIterable, Iterable};
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::ParIter;
 use orx_tree::*;
 
@@ -51,7 +51,7 @@ fn paths<T: Traverser>(tree: &DynTree<String>) -> Vec<String> {
         .unwrap()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn paths_par<T: Traverser>(tree: &DynTree<String>) -> Vec<String> {
     let root = tree.root();
     root.paths_par::<T>()
@@ -79,7 +79,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| paths::<UsedTraverser>(&data))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
             BenchmarkId::new("NodeRef::paths_par::<T>()", n),
             n,

--- a/benches/walk_iterator.rs
+++ b/benches/walk_iterator.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::*;
 use orx_tree::*;
 use rayon::iter::{ParallelBridge, ParallelIterator};
@@ -40,7 +40,7 @@ fn arbitrary_order_iter(tree: &DynTree<String>) -> i64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn arbitrary_order_par_iter(tree: &DynTree<String>) -> i64 {
     tree.par()
         .map(|x| x.parse::<usize>().unwrap())
@@ -64,7 +64,7 @@ fn walk<T: Traverser>(tree: &DynTree<String>) -> i64 {
         .sum()
 }
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 fn walk_par<T: Traverser>(tree: &DynTree<String>) -> i64 {
     tree.root()
         .walk_par::<T>()
@@ -89,7 +89,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| arbitrary_order_iter(&data))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(
             BenchmarkId::new("arbitrary_order_par_iter", n),
             n,
@@ -116,7 +116,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| walk::<Dfs>(&data))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(BenchmarkId::new("walk_par::<Dfs>", n), n, |b, _| {
             let result = walk_par::<Dfs>(&data);
             assert_eq!(result, expected);
@@ -129,7 +129,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| walk::<Bfs>(&data))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(BenchmarkId::new("walk_par::<Bfs>", n), n, |b, _| {
             let result = walk_par::<Bfs>(&data);
             assert_eq!(result, expected);
@@ -142,7 +142,7 @@ fn bench(c: &mut Criterion) {
             b.iter(|| walk::<PostOrder>(&data))
         });
 
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         group.bench_with_input(BenchmarkId::new("walk_par::<PostOrder>", n), n, |b, _| {
             let result = walk_par::<PostOrder>(&data);
             assert_eq!(result, expected);

--- a/examples/bench_parallelization.rs
+++ b/examples/bench_parallelization.rs
@@ -1,6 +1,6 @@
-// cargo run --release --features orx-parallel --example bench_parallelization
-// cargo run --release --features orx-parallel --example bench_parallelization -- --help
-// cargo run --release --features orx-parallel --example bench_parallelization -- --len 50000 --num-repetitions 20
+// cargo run --release --features parallel --example bench_parallelization
+// cargo run --release --features parallel --example bench_parallelization -- --help
+// cargo run --release --features parallel --example bench_parallelization -- --len 50000 --num-repetitions 20
 
 mod utils;
 
@@ -65,7 +65,7 @@ fn main() {
     expected_output.sort();
 
     let computations: Vec<utils::ComputeTuple<Vec<String>>> = vec![
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         (
             "Sequential computation over Tree",
             Box::new(move || {
@@ -79,9 +79,9 @@ fn main() {
                     .collect::<Vec<_>>()
             }),
         ),
-        #[cfg(feature = "orx-parallel")]
+        #[cfg(feature = "parallel")]
         (
-            "Parallelized over Tree using orx-parallel",
+            "Parallelized over Tree using parallel",
             Box::new(move || {
                 let tree = build_tree(10);
 

--- a/examples/demo_parallelization.rs
+++ b/examples/demo_parallelization.rs
@@ -1,4 +1,4 @@
-// cargo run --release --features orx-parallel --example demo_parallelization
+// cargo run --release --features parallel --example demo_parallelization
 
 use orx_tree::*;
 
@@ -34,7 +34,7 @@ fn main() {
         .sum();
     assert_eq!(total_num_characters, expected_num_characters);
 
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     {
         // computation using parallel iterator: replace `iter()` with `par()`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,5 +63,5 @@ pub use orx_selfref_col::NodeIdxError;
 // RE-IMPORT
 pub use orx_iterable::{Collection, CollectionMut};
 
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 pub use orx_parallel::*;

--- a/src/node_ref.rs
+++ b/src/node_ref.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     tree_variant::RefsChildren,
 };
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::*;
 use orx_selfref_col::{NodePtr, Refs};
 
@@ -262,7 +262,7 @@ where
     /// Please see [`children`] for details, since `children_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// You may also see [children_iterator](https://github.com/orxfun/orx-tree/blob/main/benches/children_iterator.rs) benchmark to
     /// see an example use case.
@@ -327,7 +327,7 @@ where
     /// assert_eq!(seq_value, par_value);
     /// assert_eq!(seq_value, par_value_4t);
     /// ```
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn children_par(&'a self) -> impl ParIter<Item = Node<'a, V, M, P>>
     where
         V::Item: Send + Sync,
@@ -634,13 +634,13 @@ where
     /// Please see [`ancestors`] for details, since `ancestors_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`ancestors`]: NodeRef::ancestors
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn ancestors_par(&'a self) -> impl ParIter<Item = Node<'a, V, M, P>>
     where
         V::Item: Send + Sync,
@@ -828,13 +828,13 @@ where
     /// Please see [`custom_walk`] for details, since `custom_walk_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`custom_walk`]: NodeRef::custom_walk
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn custom_walk_par<F>(&self, next_node: F) -> impl ParIter<Item = &'a V::Item>
     where
         F: Fn(Node<'a, V, M, P>) -> Option<Node<'a, V, M, P>>,
@@ -930,7 +930,7 @@ where
     /// Please see [`walk`] for details, since `walk_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// You may also see [walk_iterator](https://github.com/orxfun/orx-tree/blob/main/benches/walk_iterator.rs) benchmark to
     /// see an example use case.
@@ -939,7 +939,7 @@ where
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn walk_par<T>(&'a self) -> impl ParIter<Item = &'a V::Item>
     where
         T: Traverser<OverData>,
@@ -1109,13 +1109,13 @@ where
     /// Please see [`walk_with`] for details, since `walk_with_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`walk_with`]: NodeRef::walk_with
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn walk_with_par<'t, T, O>(
         &'a self,
         traverser: &'t mut T,
@@ -1251,7 +1251,7 @@ where
     /// Please see [`paths`] for details, since `paths_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`paths`]: NodeRef::paths
     /// [parallel iterator]: orx_parallel::ParIter
@@ -1333,7 +1333,7 @@ where
     /// let expected = [1364, 340, 84, 20, 4, 0].map(|x| x.to_string());
     /// assert_eq!(best_path, expected.iter().collect::<Vec<_>>());
     /// ```
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn paths_par<T>(&'a self) -> impl ParIter<Item = impl Iterator<Item = &'a V::Item> + Clone>
     where
         T: Traverser<OverData>,
@@ -1472,7 +1472,7 @@ where
     /// Please see [`paths_with`] for details, since `paths_with_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`paths_with`]: NodeRef::paths_with
     /// [parallel iterator]: orx_parallel::ParIter
@@ -1552,7 +1552,7 @@ where
     /// let expected = [1364, 340, 84, 20, 4, 0].map(|x| x.to_string());
     /// assert_eq!(best_path, expected.iter().collect::<Vec<_>>());
     /// ```
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn paths_with_par<T, O>(
         &'a self,
         traverser: &'a mut T,
@@ -1732,13 +1732,13 @@ where
     /// Please see [`leaves`] for details, since `leaves_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`leaves`]: NodeRef::leaves
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn leaves_par<T>(&'a self) -> impl ParIter<Item = &'a V::Item>
     where
         T: Traverser<OverData>,
@@ -1854,13 +1854,13 @@ where
     /// Please see [`leaves_with`] for details, since `leaves_with_par` is the parallelized counterpart.
     /// * Parallel iterators can be used similar to regular iterators.
     /// * Parallel computation can be configured by using methods such as [`num_threads`] or [`chunk_size`] on the parallel iterator.
-    /// * Parallel counterparts of the tree iterators are available with **orx-parallel** feature.
+    /// * Parallel counterparts of the tree iterators are available with **parallel** feature.
     ///
     /// [`leaves_with`]: NodeRef::leaves_with
     /// [parallel iterator]: orx_parallel::ParIter
     /// [`num_threads`]: orx_parallel::ParIter::num_threads
     /// [`chunk_size`]: orx_parallel::ParIter::chunk_size
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn leaves_with_par<T, O>(
         &'a self,
         traverser: &'a mut T,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -961,7 +961,7 @@ where
     /// In brief, computation is defined as chain of iterator transformations and parallelization
     /// is handled by the underlying parallel executor.
     ///
-    /// Requires **orx-parallel** feature.
+    /// Requires **parallel** feature.
     ///
     /// [`ParIter`]: orx_parallel::ParIter
     /// [`walk`]: crate::NodeRef::walk
@@ -1015,7 +1015,7 @@ where
     ///     .sum();
     /// assert_eq!(seq_result, par_result);
     /// ```
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     pub fn par(&self) -> impl orx_parallel::ParIter<Item = &V::Item>
     where
         V::Item: Send + Sync,
@@ -1039,7 +1039,7 @@ where
     /// In brief, computation is defined as chain of iterator transformations and parallelization
     /// is handled by the underlying parallel executor.
     ///
-    /// Requires **orx-parallel** feature.
+    /// Requires **parallel** feature.
     ///
     /// [`ParIter`]: orx_parallel::ParIter
     /// [`walk`]: crate::NodeRef::walk
@@ -1095,7 +1095,7 @@ where
     ///     .sum();
     /// assert_eq!(seq_result, par_result);
     /// ```
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     pub fn into_par(self) -> impl orx_parallel::ParIter<Item = V::Item>
     where
         V::Item: Send + Sync + Clone,

--- a/src/tree_variant.rs
+++ b/src/tree_variant.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "orx-parallel")]
+#[cfg(feature = "parallel")]
 use orx_parallel::*;
 use orx_selfref_col::{
     MemoryReclaimer, NodePtr, Refs, RefsArrayLeftMost, RefsSingle, RefsVec, Variant,
@@ -30,7 +30,7 @@ pub trait RefsChildren<V: Variant> {
 
     fn children_ptr(&self) -> Self::ChildrenPtrIter<'_>;
 
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn children_ptr_par<'a>(&'a self) -> impl ParIter<Item = &'a NodePtr<V>>
     where
         V: 'a,
@@ -68,7 +68,7 @@ impl<V: Variant> RefsChildren<V> for RefsVec<V> {
         self.iter()
     }
 
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn children_ptr_par<'a>(&'a self) -> impl ParIter<Item = &'a NodePtr<V>>
     where
         V: 'a,
@@ -119,7 +119,7 @@ impl<const D: usize, V: Variant> RefsChildren<V> for RefsArrayLeftMost<D, V> {
         self.iter()
     }
 
-    #[cfg(feature = "orx-parallel")]
+    #[cfg(feature = "parallel")]
     fn children_ptr_par<'a>(&'a self) -> impl ParIter<Item = &'a NodePtr<V>>
     where
         V: 'a,


### PR DESCRIPTION
This PR changes `orx-parallel` to be a explicit feature, which makes it easier to discover and reason about. Before it was a implicit feature created by `optional = true` on the crate.

Maybe it should also be renamed to just `parallel` or `par-iter`?