### PR TITLE
chore(Cargo.toml): list all benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,22 @@ serde = ["dep:serde"]
 name = "walk_iterator"
 harness = false
 
+[[bench]]
+name = "children_iterator"
+harness = false
+
+[[bench]]
+name = "parallelization_owned"
+harness = false
+
+[[bench]]
+name = "parallelization_ref"
+harness = false
+
+[[bench]]
+name = "paths_iterator"
+harness = false
+
 # Lints that apply to all files and targets
 [lints.clippy]
 uninlined_format_args = "warn"


### PR DESCRIPTION
As otherwise they dont get run with criterion, they get run as tests.

Before this PR:
```sh
$ cargo bench --bench=children_iterator
   Compiling orx-tree v1.10.0 (/mnt/ssd/projects/rust/orx-tree)
    Finished `bench` profile [optimized] target(s) in 0.56s
     Running benches/children_iterator.rs (target/release/deps/children_iterator-0c26877b1b49e54c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

After:

```sh
$ cargo bench --bench=children_iterator
   Compiling orx-tree v1.10.0 (/mnt/ssd/projects/rust/orx-tree)
    Finished `bench` profile [optimized] target(s) in 0.73s
     Running benches/children_iterator.rs (target/release/deps/children_iterator-0c26877b1b49e54c)
Gnuplot not found, using plotters backend
Benchmarking children_iterator/NodeRef::children()/65536: Collecting 100 samples in estimated 5.6003 s (600 iteratiochildren_iterator/NodeRef::children()/65536
                        time:   [9.3592 ms 9.3858 ms 9.4154 ms]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
Benchmarking children_iterator/NNodeRef::children_par()/65536: Collecting 100 samples in estimated 5.5793 s (600 itechildren_iterator/NNodeRef::children_par()/65536
                        time:   [9.2729 ms 9.2787 ms 9.2852 ms]
Found 12 outliers among 100 measurements (12.00%)
  10 (10.00%) high mild
  2 (2.00%) high severe
Benchmarking children_iterator/NodeRef::children_par().num_threads(2)/65536: Collecting 100 samples in estimated 5.6children_iterator/NodeRef::children_par().num_threads(2)/65536
                        time:   [9.3155 ms 9.3326 ms 9.3516 ms]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
```