### PR TITLE
fix(tree_node_idx): implement "Eq"

### DIFF
--- a/src/tree_node_idx.rs
+++ b/src/tree_node_idx.rs
@@ -304,6 +304,8 @@ impl<V: TreeVariant> PartialEq for NodeIdx<V> {
     }
 }
 
+impl<V: TreeVariant> Eq for NodeIdx<V> {}
+
 impl<V: TreeVariant> Debug for NodeIdx<V> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.0)


### PR DESCRIPTION
Re #171, turns out `HashMap` & `HashSet(key)` require it to implement `Eq`, which the [`NodeIdx` in `orx-selfref-col` does](https://github.com/orxfun/orx-selfref-col/blob/f3c3c3199c0e7af9c913ae1e1456a8feb07d3006/src/references/node_idx.rs#L54), but this one does not.